### PR TITLE
S45 - Fix pypi homepage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def long_description():
 setup(
     name="spb-cli",
     version=__version__,
-    url="https://github.com/Superb-AI-Suite/cool-tree.git",
+    url="https://github.com/Superb-AI-Suite/spb-cli.git",
     license="MIT",
     author="Superb AI",
     author_email="support@superb-ai.com",


### PR DESCRIPTION
지금 spb-cli pypi 가면 homepage link가 cool-tree로 돼있어서 이걸 고쳐야되지 않나 싶은데 이렇게 하면 될까요?