### PR TITLE
Fix tag bug

### DIFF
--- a/spb/__init__.py
+++ b/spb/__init__.py
@@ -32,7 +32,7 @@ from spb.exceptions.exceptions import CommandInitiationFailedException
 
 
 __author__  = 'Super AI Dev Team'
-__version__ = '0.0.42'
+__version__ = '0.0.43'
 
 
 DEFAULT_SESSION = None

--- a/spb/cli_core/commands/label_data.py
+++ b/spb/cli_core/commands/label_data.py
@@ -262,11 +262,11 @@ def _update_label(args):
     except Exception as e:
         _set_error_result(data_key, result, str(e), e)
         return
-
+    
     label = {
         "id": described_label.id,
         "project_id": project_id,
-        "tags": described_label.tags,
+        "tags": [tag.get_datas(tag) for tag in described_label.tags],
         "result": described_label.result,
     }
     try:
@@ -279,7 +279,6 @@ def _update_label(args):
             label['result'] = json_data['result']
         if 'tags' in json_data:
             label['tags'] = json_data['tags']
-
         command = spb.Command(type='update_label')
         label = spb.run(command=command, option=label)
         with open(label_path, 'w') as f:


### PR DESCRIPTION
Error :
If label already has tags and user label json doesn't have 'tags' key,
an error will occur.

Fix :
if label json doesn’t have tags key, tags key in label will not be updated.
