### PR TITLE
Add filter to label status

### DIFF
--- a/spb/__init__.py
+++ b/spb/__init__.py
@@ -32,7 +32,7 @@ from spb.exceptions.exceptions import CommandInitiationFailedException
 
 
 __author__  = 'Super AI Dev Team'
-__version__ = '0.0.43'
+__version__ = '0.1.0'
 
 
 DEFAULT_SESSION = None

--- a/spb/models/label.py
+++ b/spb/models/label.py
@@ -26,7 +26,7 @@ class Label(Model):
     tags = Object(property_name='tags', express=Tags, filterable=True)
 
     # basic info
-    status = String(property_name='status', immutable=True)
+    status = String(property_name='status', immutable=True, filterable=True)
     stats = Object(property_name='stats', immutable=True, express=Stats)
 
     # For assets


### PR DESCRIPTION
Issue : 
Label cannot have been described by label status.

Improvement : 
You can now use the status parameter to filter your label results