### PR TITLE
fix import requests

### DIFF
--- a/spb/session.py
+++ b/spb/session.py
@@ -1,6 +1,11 @@
 import os
 import configparser
-import requests
+try:
+    import requests
+except ImportError:
+    from pip._internal import main as pip
+    pip(['install', '--user', 'requests'])
+    import requests
 import json
 import copy
 import base64


### PR DESCRIPTION
Setup assumes you already have installed **requests** 
Even though requests is inside a requirements.txt

```
Collecting requests
  Using cached requests-2.28.1-py3-none-any.whl (62 kB)
Collecting spb-cli
  Using cached spb-cli-0.13.0.tar.gz (54 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [10 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/private/var/folders/s5/gnp79n6d42g91g91vt5jj_zw0000gn/T/pip-install-efc1pvz4/spb-cli_d8c9788496674ed0b92edd78e602cecc/setup.py", line 4, in <module>
          from spb.sdk_config import SDK_VERSION, SDK_AUTHOR, SDK_AUTHOR_EMAIL, SDK_DESCRIPTION, SDK_LICENSE, SDK_NAME, SDK_URL
        File "/private/var/folders/s5/gnp79n6d42g91g91vt5jj_zw0000gn/T/pip-install-efc1pvz4/spb-cli_d8c9788496674ed0b92edd78e602cecc/spb/__init__.py", line 27, in <module>
          from spb.session import Session
        File "/private/var/folders/s5/gnp79n6d42g91g91vt5jj_zw0000gn/T/pip-install-efc1pvz4/spb-cli_d8c9788496674ed0b92edd78e602cecc/spb/session.py", line 3, in <module>
          import requests
      ModuleNotFoundError: No module named 'requests'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.

```